### PR TITLE
Remove the shebang from __init__.py

### DIFF
--- a/jinja2_pluralize/__init__.py
+++ b/jinja2_pluralize/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 __author__ = 'Audrey Roy'


### PR DESCRIPTION
There is no **main** code in the module file, so there's no point in
having the file look like a python executable.

rpmlint complained about this while I was trying to create a package and I figured it was a simple enough change.
